### PR TITLE
Fix automatic versioning

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -1,9 +1,9 @@
 name: Lib-ml Delivery
 
-on:
-  push:
-    branches:
-      - main
+on: push
+  # push:
+  #   branches:
+  #     - main
 
 jobs:
   delivery:
@@ -22,7 +22,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           release_branches: 'NONE'
-          pre_release_branches: main
+          # pre_release_branches: main
           default_prerelease_bump: prerelease
           append_to_pre_release_tag: pre
           tag_prefix: v

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -1,9 +1,9 @@
 name: Lib-ml Delivery
 
-on: push
-  # push:
-  #   branches:
-  #     - main
+on: 
+  push:
+    branches:
+      - main
 
 jobs:
   delivery:

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           release_branches: 'NONE'
-          # pre_release_branches: main
+          pre_release_branches: main
           default_prerelease_bump: prerelease
           append_to_pre_release_tag: pre
           tag_prefix: v

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,17 +1,17 @@
 name: Lib-ml Deployment
 
-on: 
-  workflow_dispatch:
-    inputs:
-      bump_level:
-        description: 'Specify the type of version bump for the new release.'
-        required: false
-        type: choice 
-        options:   
-          - patch
-          - minor
-          - major
-        default: 'patch' 
+on: push
+  # workflow_dispatch:
+  #   inputs:
+  #     bump_level:
+  #       description: 'Specify the type of version bump for the new release.'
+  #       required: false
+  #       type: choice 
+  #       options:   
+  #         - patch
+  #         - minor
+  #         - major
+  #       default: 'patch' 
 
 jobs:
   delivery:
@@ -24,15 +24,28 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Create empty commit for stable release
+        run: |
+          git commit --allow-empty -m "Empty commit for stable release [skip ci]"
+          git push
+
       - name: Bump stable version and push tag
         id: bump_version
         uses: mathieudutour/github-tag-action@v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          release_branches: main
+          # release_branches: main
           pre_release_branches: 'NONE'
           default_bump: ${{ inputs.bump_level }}
           tag_prefix: v
+
+      - name: Checkout code at release commit
+        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -70,12 +83,17 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Add new pre release
-        uses: mathieudutour/github-tag-action@v6.2
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          release_branches: 'NONE'
-          pre_release_branches: main
-          default_prerelease_bump: prerelease
-          append_to_pre_release_tag: pre
-          tag_prefix: v
+      - name: Create empty commit for next pre-release
+        run: |
+          git commit --allow-empty -m "Empty commit for nex pre-release"
+          git push
+
+      # - name: Add new pre release
+      #   uses: mathieudutour/github-tag-action@v6.2
+      #   with:
+      #     github_token: ${{ secrets.GITHUB_TOKEN }}
+      #     release_branches: 'NONE'
+      #     pre_release_branches: main
+      #     default_prerelease_bump: prerelease
+      #     append_to_pre_release_tag: pre
+      #     tag_prefix: v

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -39,7 +39,7 @@ jobs:
         uses: mathieudutour/github-tag-action@v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          release_branches: fix-automatic-versioning
+          release_branches: 'Fix-automatic-versioning'
           pre_release_branches: 'NONE'
           # default_bump: ${{ inputs.bump_level }}
           default_bump: patch

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -47,8 +47,6 @@ jobs:
 
       - name: Checkout code at release commit
         uses: actions/checkout@v4
-        with:
-          ref: ${{ steps.bump_version.outputs.new_tag }}
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -39,7 +39,7 @@ jobs:
         uses: mathieudutour/github-tag-action@v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          # release_branches: main
+          release_branches: fix-automatic-versioning
           pre_release_branches: 'NONE'
           # default_bump: ${{ inputs.bump_level }}
           default_bump: patch

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -41,7 +41,8 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # release_branches: main
           pre_release_branches: 'NONE'
-          default_bump: ${{ inputs.bump_level }}
+          # default_bump: ${{ inputs.bump_level }}
+          default_bump: patch
           tag_prefix: v
 
       - name: Checkout code at release commit

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -24,15 +24,15 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Configure Git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+      # - name: Configure Git
+      #   run: |
+      #     git config user.name "github-actions[bot]"
+      #     git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Create empty commit for stable release
-        run: |
-          git commit --allow-empty -m "Empty commit for stable release [skip ci]"
-          git push
+      # - name: Create empty commit for stable release
+      #   run: |
+      #     git commit --allow-empty -m "Empty commit for stable release [skip ci]"
+      #     git push
 
       - name: Bump stable version and push tag
         id: bump_version
@@ -44,9 +44,12 @@ jobs:
           # default_bump: ${{ inputs.bump_level }}
           default_bump: patch
           tag_prefix: v
+          custom_message: "Create empty commit for stable release [skip ci]"
 
       - name: Checkout code at release commit
         uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.bump_version.outputs.new_tag }}
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -24,15 +24,15 @@ jobs:
         with:
           fetch-depth: 0
 
-      # - name: Configure Git
-      #   run: |
-      #     git config user.name "github-actions[bot]"
-      #     git config user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      # - name: Create empty commit for stable release
-      #   run: |
-      #     git commit --allow-empty -m "Empty commit for stable release [skip ci]"
-      #     git push
+      - name: Create empty commit for stable release
+        run: |
+          git commit --allow-empty -m "Empty commit for stable release [skip ci]"
+          git push
 
       - name: Bump stable version and push tag
         id: bump_version
@@ -44,7 +44,6 @@ jobs:
           # default_bump: ${{ inputs.bump_level }}
           default_bump: patch
           tag_prefix: v
-          custom_message: "Create empty commit for stable release [skip ci]"
 
       - name: Checkout code at release commit
         uses: actions/checkout@v4
@@ -92,6 +91,7 @@ jobs:
 
       - name: Create empty commit for next pre-release
         run: |
+          git pull
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git commit --allow-empty -m "Empty commit for next pre-release"

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -39,10 +39,10 @@ jobs:
         uses: mathieudutour/github-tag-action@v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          release_branches: 'Fix-automatic-versioning'
+          # release_branches: main
+          release_branches: '*'
           pre_release_branches: 'NONE'
-          # default_bump: ${{ inputs.bump_level }}
-          default_bump: patch
+          default_bump: ${{ inputs.bump_level }}
           tag_prefix: v
 
       - name: Checkout code at release commit

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,17 +1,17 @@
 name: Lib-ml Deployment
 
-on: push
-  # workflow_dispatch:
-  #   inputs:
-  #     bump_level:
-  #       description: 'Specify the type of version bump for the new release.'
-  #       required: false
-  #       type: choice 
-  #       options:   
-  #         - patch
-  #         - minor
-  #         - major
-  #       default: 'patch' 
+on:
+  workflow_dispatch:
+    inputs:
+      bump_level:
+        description: 'Specify the type of version bump for the new release.'
+        required: false
+        type: choice 
+        options:   
+          - patch
+          - minor
+          - major
+        default: 'patch' 
 
 jobs:
   delivery:
@@ -29,25 +29,15 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      # - name: Create empty commit for stable release
-      #   run: |
-      #     git commit --allow-empty -m "Empty commit for stable release [skip ci]"
-      #     git push
-      #     COMMIT_SHA=$(git rev-parse HEAD)
-      #     echo "commit_sha=$COMMIT_SHA" >> $GITHUB_OUTPUT
-      #     echo "Created release commit with SHA: $COMMIT_SHA"
-
       - name: Bump stable version and push tag
         id: bump_version
         uses: mathieudutour/github-tag-action@v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          # release_branches: main
+          release_branches: main
           dry_run: true
-          release_branches: ${{ github.ref_name }}
           pre_release_branches: 'NONE'
-          # default_bump: ${{ inputs.bump_level }}
-          default_bump: patch
+          default_bump: ${{ inputs.bump_level }}
           tag_prefix: v
       
       - name: Create release commit and tag
@@ -100,13 +90,3 @@ jobs:
           git pull
           git commit --allow-empty -m "Empty commit for next pre-release"
           git push
-
-      # - name: Add new pre release
-      #   uses: mathieudutour/github-tag-action@v6.2
-      #   with:
-      #     github_token: ${{ secrets.GITHUB_TOKEN }}
-      #     release_branches: 'NONE'
-      #     pre_release_branches: main
-      #     default_prerelease_bump: prerelease
-      #     append_to_pre_release_tag: pre
-      #     tag_prefix: v

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -42,7 +42,8 @@ jobs:
           # release_branches: main
           release_branches: ${{ github.ref_name }}
           pre_release_branches: 'NONE'
-          default_bump: ${{ inputs.bump_level }}
+          # default_bump: ${{ inputs.bump_level }}
+          default_bump: patch
           tag_prefix: v
 
       - name: Checkout code at release commit

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -33,6 +33,7 @@ jobs:
         run: |
           git commit --allow-empty -m "Empty commit for stable release [skip ci]"
           git push
+          git pull
 
       - name: Bump stable version and push tag
         id: bump_version

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -33,7 +33,9 @@ jobs:
         run: |
           git commit --allow-empty -m "Empty commit for stable release [skip ci]"
           git push
-          git pull
+          COMMIT_SHA=$(git rev-parse HEAD)
+          echo "commit_sha=$COMMIT_SHA" >> $GITHUB_OUTPUT
+          echo "Created release commit with SHA: $COMMIT_SHA"
 
       - name: Bump stable version and push tag
         id: bump_version
@@ -42,6 +44,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # release_branches: main
           release_branches: ${{ github.ref_name }}
+          commit_sha: ${{ steps.create_release_commit.outputs.commit_sha }}
           pre_release_branches: 'NONE'
           # default_bump: ${{ inputs.bump_level }}
           default_bump: patch

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -29,13 +29,13 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Create empty commit for stable release
-        run: |
-          git commit --allow-empty -m "Empty commit for stable release [skip ci]"
-          git push
-          COMMIT_SHA=$(git rev-parse HEAD)
-          echo "commit_sha=$COMMIT_SHA" >> $GITHUB_OUTPUT
-          echo "Created release commit with SHA: $COMMIT_SHA"
+      # - name: Create empty commit for stable release
+      #   run: |
+      #     git commit --allow-empty -m "Empty commit for stable release [skip ci]"
+      #     git push
+      #     COMMIT_SHA=$(git rev-parse HEAD)
+      #     echo "commit_sha=$COMMIT_SHA" >> $GITHUB_OUTPUT
+      #     echo "Created release commit with SHA: $COMMIT_SHA"
 
       - name: Bump stable version and push tag
         id: bump_version
@@ -43,12 +43,22 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # release_branches: main
+          dry-run: true
           release_branches: ${{ github.ref_name }}
-          commit_sha: ${{ steps.create_release_commit.outputs.commit_sha }}
           pre_release_branches: 'NONE'
           # default_bump: ${{ inputs.bump_level }}
           default_bump: patch
           tag_prefix: v
+      
+      - name: Create release commit and tag
+        id: create_release
+        run: |
+          NEW_TAG=${{ steps.bump_version.outputs.new_tag }}
+
+          git commit --allow-empty -m "Release ${NEW_TAG} [skip ci]"
+          git tag $NEW_TAG
+          git push origin HEAD --tags
+          echo "new_tag=${NEW_TAG}" >> $GITHUB_OUTPUT
 
       - name: Checkout code at release commit
         uses: actions/checkout@v4

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # release_branches: main
-          dry-run: true
+          dry_run: true
           release_branches: ${{ github.ref_name }}
           pre_release_branches: 'NONE'
           # default_bump: ${{ inputs.bump_level }}

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -83,10 +83,15 @@ jobs:
           files: dist/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Checkout branch head to prepare for trigger
+        uses: actions/checkout@v4
 
       - name: Create empty commit for next pre-release
         run: |
-          git commit --allow-empty -m "Empty commit for nex pre-release"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit --allow-empty -m "Empty commit for next pre-release"
           git push
 
       # - name: Add new pre release

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -99,14 +99,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       
-      - name: Checkout branch head to prepare for trigger
-        uses: actions/checkout@v4
 
       - name: Create empty commit for next pre-release
         run: |
-          git pull
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
           git commit --allow-empty -m "Empty commit for next pre-release"
           git push
 

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -54,14 +54,10 @@ jobs:
         id: create_release
         run: |
           NEW_TAG=${{ steps.bump_version.outputs.new_tag }}
-
           git commit --allow-empty -m "Release ${NEW_TAG} [skip ci]"
           git tag $NEW_TAG
           git push origin HEAD --tags
           echo "new_tag=${NEW_TAG}" >> $GITHUB_OUTPUT
-
-      - name: Checkout code at release commit
-        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -98,10 +94,10 @@ jobs:
           files: dist/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
 
       - name: Create empty commit for next pre-release
         run: |
+          git pull
           git commit --allow-empty -m "Empty commit for next pre-release"
           git push
 

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # release_branches: main
-          release_branches: '*'
+          release_branches: ${{ github.ref_name }}
           pre_release_branches: 'NONE'
           default_bump: ${{ inputs.bump_level }}
           tag_prefix: v


### PR DESCRIPTION
Added automatic versioning with the modifications taken from the Q&A with Sebastian. 
For each push to main, a pre-release is made. 
When clicking the workflow dispatch button in the worflow tab, you can decide on a stable release:
![image](https://github.com/user-attachments/assets/1a2b1f34-761b-475a-b649-ac4906a3dacf)
This release will be done on a new empty commit and then another empty commit is done for the next pre release.